### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ A Model Context Protocol (MCP) server for managing Google Tasks.
 
 This TypeScript-based MCP server demonstrates core MCP concepts by integrating with the Google Tasks API. It allows managing tasks in a structured and efficient way.
 
+<a href="https://glama.ai/mcp/servers/dl82dtjqew">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/dl82dtjqew/badge" alt="Google Tasks Server MCP server" />
+</a>
+
 ---
 
 ## Features


### PR DESCRIPTION
This PR adds a badge for the [Google Tasks MCP Server](https://glama.ai/mcp/servers/dl82dtjqew) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/dl82dtjqew">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/dl82dtjqew/badge" alt="Google Tasks Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.